### PR TITLE
Fix sidebar display issue for firefox users

### DIFF
--- a/OpenWasteMapUK/OpenWasteMapUK/wwwroot/css/site.css
+++ b/OpenWasteMapUK/OpenWasteMapUK/wwwroot/css/site.css
@@ -18,7 +18,7 @@
 
 .sidebar-sticky {
     position: -webkit-sticky;
-    position: sticky;
+    position: fixed;
     top: 48px; /* Height of navbar */
     height: calc(100vh - 48px);
     padding-top: .5rem;


### PR DESCRIPTION
Fix sidebar display issue for firefox users causing the postcode input box to ride up and under the top nav bar for.

Turns out to be a bug in firefox https://bugzilla.mozilla.org/show_bug.cgi?id=1488080 (`position: sticky` does not play well with an outer element having `display: flex`). Swapping to `position: fixed` is perhaps semantically less elegant, but it works. I've tested it doesn't break anything in chrome & safari.

Partly fixes: https://github.com/JackGilmore/OpenWasteMap/issues/8