### PR TITLE
"Your local authority area is null"

### DIFF
--- a/OpenWasteMapUK/OpenWasteMapUK/Models/PostcodesDotIO/Codes.cs
+++ b/OpenWasteMapUK/OpenWasteMapUK/Models/PostcodesDotIO/Codes.cs
@@ -1,0 +1,25 @@
+﻿using Newtonsoft.Json;
+
+namespace OpenWasteMapUK.Models.PostcodesDotIO
+{
+    public class Codes
+    {
+        [JsonProperty("admin_district")]
+        public string AdminDistrict { get; set; }
+        [JsonProperty("admin_county")]
+        public string AdminCounty { get; set; }
+        [JsonProperty("admin_ward")]
+        public string AdminWard { get; set; }
+        public string Parish { get; set; }
+        [JsonProperty("parliamentary_constituency")]
+        public string ParliamentaryConstituency { get; set; }
+        public string Ccg { get; set; }
+        [JsonProperty("ccg_id")]
+        public string CcgId { get; set; }
+        public string Ced { get; set; }
+        public string Nuts { get; set; }
+        public string Lsoa { get; set; }
+        public string Msoa { get; set; }
+        public string Lau2 { get; set; }
+    }
+}

--- a/OpenWasteMapUK/OpenWasteMapUK/Models/PostcodesDotIO/PostcodeResult.cs
+++ b/OpenWasteMapUK/OpenWasteMapUK/Models/PostcodesDotIO/PostcodeResult.cs
@@ -1,0 +1,9 @@
+﻿namespace OpenWasteMapUK.Models.PostcodesDotIO
+{
+    public class PostcodeResult
+    {
+        public int Status { get; set; }
+        public ResultBody Result { get; set; }
+        public string Error { get; set; }
+    }
+}

--- a/OpenWasteMapUK/OpenWasteMapUK/Models/PostcodesDotIO/ResultBody.cs
+++ b/OpenWasteMapUK/OpenWasteMapUK/Models/PostcodesDotIO/ResultBody.cs
@@ -1,0 +1,39 @@
+﻿using Newtonsoft.Json;
+
+namespace OpenWasteMapUK.Models.PostcodesDotIO
+{
+    public class ResultBody
+    {
+        public string Postcode { get; set; }
+        public int Quality { get; set; }
+        public int Eastings { get; set; }
+        public int Northings { get; set; }
+        public string Country { get; set; }
+        [JsonProperty("nhs_sa")]
+        public string NhsHa { get; set; }
+        public float Longitude { get; set; }
+        public float Latitude { get; set; }
+        [JsonProperty("european_electoral_region")]
+        public string EuropeanElectoralRegion { get; set; }
+        [JsonProperty("primary_care_trust")]
+        public string PrimaryCareTrust { get; set; }
+        public string Region { get; set; }
+        public string Lsoa { get; set; }
+        public string Msoa { get; set; }
+        public string InCode { get; set; }
+        public string OutCode { get; set; }
+        [JsonProperty("parliamentary_constituency")]
+        public string ParliamentaryConstituency { get; set; }
+        [JsonProperty("admin_district")]
+        public string AdminDistrict { get; set; }
+        public string Parish { get; set; }
+        [JsonProperty("admin_county")]
+        public string AdminCounty { get; set; }
+        [JsonProperty("admin_ward")]
+        public string AdminWard { get; set; }
+        public string Ced { get; set; }
+        public string Ccg { get; set; }
+        public string Nuts { get; set; }
+        public Codes Codes { get; set; }
+    }
+}

--- a/OpenWasteMapUK/OpenWasteMapUK/OpenWasteMapUK.csproj
+++ b/OpenWasteMapUK/OpenWasteMapUK/OpenWasteMapUK.csproj
@@ -29,7 +29,7 @@
 		<Folder Include="App_Data\" />
 	</ItemGroup>
 	<ItemGroup>
-		<Content Include="Data\**" CopyToPublishDirectory="PreserveNewest"/>
+		<Content Include="Data\**" CopyToPublishDirectory="PreserveNewest" />
 	</ItemGroup>
 	<ItemGroup>
 		<None Update="Data\**">

--- a/OpenWasteMapUK/OpenWasteMapUK/wwwroot/js/map.js
+++ b/OpenWasteMapUK/OpenWasteMapUK/wwwroot/js/map.js
@@ -291,7 +291,7 @@ function search() {
                     popupAnchor: [1, -34],
                     shadowSize: [41, 41]
                 });
-                if (layer.properties.hasOwnProperty(data.wasteOSMTag) && layer.properties[data.wasteOSMTag] === 'yes' && layer.properties.owner.includes(data.councilArea)) {
+                if (layer.properties.hasOwnProperty(data.wasteOSMTag) && layer.properties[data.wasteOSMTag] === "yes" && layer.properties.hasOwnProperty("owner") && layer.properties.owner.includes(data.councilArea)) {
                     icon.options.iconUrl = '/lib/leaflet/images/marker-icon-green.png';
                     listText += `<li class="list-group-item">${layer.properties.name}</li>`;
                     hwrcMatchCount++;


### PR DESCRIPTION
In some areas of England `admin_county` was coming back as null and as a result the postcode lookup was displaying a message saying "Your local authority area is null".

I've changed this to fall back to `admin_district` when `admin_county` is null.

I also solved an issue that was causing errors if an HWRC does not have an owner tag on it. 